### PR TITLE
Fixed spelling error on about page (Closes #14)

### DIFF
--- a/go/go/templates/about.html
+++ b/go/go/templates/about.html
@@ -36,7 +36,7 @@ SRCT Go &bull; About
       member.
       <br></br>
       Additionally, any link that you create is subject to removal by Go admins if it is
-      deemed to associate the univeristy with any
+      deemed to associate the university with any
       <br /> derogatory or controversial matters.
       <br></br>
       Go admins also reserve the right to remove and ban any users who attempt to abuse


### PR DESCRIPTION
Fixed the misspelling of "university" on the about page.
Closes #14 